### PR TITLE
Dependency plugins error handle

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -158,12 +158,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "928a96f585b86224ebc78f8f09d0482cf15b04f5"
+                "reference": "f6f48cfecf52ab791fe18cc1b11d6345512dc4b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/928a96f585b86224ebc78f8f09d0482cf15b04f5",
-                "reference": "928a96f585b86224ebc78f8f09d0482cf15b04f5",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/f6f48cfecf52ab791fe18cc1b11d6345512dc4b8",
+                "reference": "f6f48cfecf52ab791fe18cc1b11d6345512dc4b8",
                 "shasum": ""
             },
             "require": {
@@ -211,7 +211,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-08T17:24:01+00:00"
+            "time": "2023-07-30T10:01:33+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -219,12 +219,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "36d8a21e851a9512db2b086dc5ac2c61308f0138"
+                "reference": "67729272c564ab9f953c81f48db44e8b1cb1e1c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/36d8a21e851a9512db2b086dc5ac2c61308f0138",
-                "reference": "36d8a21e851a9512db2b086dc5ac2c61308f0138",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/67729272c564ab9f953c81f48db44e8b1cb1e1c3",
+                "reference": "67729272c564ab9f953c81f48db44e8b1cb1e1c3",
                 "shasum": ""
             },
             "require": {
@@ -233,7 +233,7 @@
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
-                "php": "^7.2 || ^8.0"
+                "php": "^7.3 || ^8.0"
             },
             "default-branch": true,
             "type": "library",
@@ -279,7 +279,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-21T19:55:33+00:00"
+            "time": "2023-06-01T14:19:47+00:00"
         },
         {
             "name": "phar-io/version",
@@ -457,12 +457,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "262f9d81273932315d15d704f69b9d678b939cb3"
+                "reference": "96bce8776a2a83c6bad3a7e1ae75b2598b660197"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/262f9d81273932315d15d704f69b9d678b939cb3",
-                "reference": "262f9d81273932315d15d704f69b9d678b939cb3",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/96bce8776a2a83c6bad3a7e1ae75b2598b660197",
+                "reference": "96bce8776a2a83c6bad3a7e1ae75b2598b660197",
                 "shasum": ""
             },
             "require": {
@@ -505,7 +505,7 @@
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2023-01-05T13:34:27+00:00"
+            "time": "2023-08-18T03:16:17+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
@@ -513,24 +513,24 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "056ac4d6ba120e4fa905b7fe43f098dfb21b812d"
+                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/056ac4d6ba120e4fa905b7fe43f098dfb21b812d",
-                "reference": "056ac4d6ba120e4fa905b7fe43f098dfb21b812d",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
                 "squizlabs/php_codesniffer": "^3.7.1"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcsstandards/phpcsdevcs": "^1.1.5",
-                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
                 "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
             },
             "default-branch": true,
@@ -569,7 +569,7 @@
                 "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
                 "source": "https://github.com/PHPCSStandards/PHPCSExtra"
             },
-            "time": "2023-05-19T06:11:13+00:00"
+            "time": "2023-09-20T22:06:18+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
@@ -577,12 +577,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "5a85dc13aa9439dc5119e6a0950bc6d4e008e23f"
+                "reference": "77a6aa4e6abc437eb0cb71702c1a635655a33af8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5a85dc13aa9439dc5119e6a0950bc6d4e008e23f",
-                "reference": "5a85dc13aa9439dc5119e6a0950bc6d4e008e23f",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/77a6aa4e6abc437eb0cb71702c1a635655a33af8",
+                "reference": "77a6aa4e6abc437eb0cb71702c1a635655a33af8",
                 "shasum": ""
             },
             "require": {
@@ -595,7 +595,7 @@
                 "php-parallel-lint/php-console-highlighter": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
-                "yoast/phpunit-polyfills": "^1.0.5"
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
             },
             "default-branch": true,
             "type": "phpcodesniffer-standard",
@@ -643,7 +643,7 @@
                 "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
                 "source": "https://github.com/PHPCSStandards/PHPCSUtils"
             },
-            "time": "2023-05-27T14:12:42+00:00"
+            "time": "2023-09-13T20:12:39+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -949,12 +949,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f7e7556c4089d14f9b0d2887350db35071438bf9"
+                "reference": "622d0186707f39a4ae71df3bcf42d759bb868854"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f7e7556c4089d14f9b0d2887350db35071438bf9",
-                "reference": "f7e7556c4089d14f9b0d2887350db35071438bf9",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/622d0186707f39a4ae71df3bcf42d759bb868854",
+                "reference": "622d0186707f39a4ae71df3bcf42d759bb868854",
                 "shasum": ""
             },
             "require": {
@@ -1023,7 +1023,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.34"
             },
             "funding": [
                 {
@@ -1039,7 +1039,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-28T06:55:25+00:00"
+            "time": "2023-09-19T05:20:51+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1382,12 +1382,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921"
+                "reference": "66783ce213de415b451b904bfef9dda0cf9aeae0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/de036ec91d55d2a9e0db2ba975b512cdb1c23921",
-                "reference": "de036ec91d55d2a9e0db2ba975b512cdb1c23921",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/66783ce213de415b451b904bfef9dda0cf9aeae0",
+                "reference": "66783ce213de415b451b904bfef9dda0cf9aeae0",
                 "shasum": ""
             },
             "require": {
@@ -1438,7 +1438,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-10T06:55:38+00:00"
+            "time": "2023-08-02T09:23:32+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1776,12 +1776,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d148febc2a2eb82972121d7f962883f7a5697b55"
+                "reference": "7566b4d89de1d08d2a8ad85910507d6633a35d28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d148febc2a2eb82972121d7f962883f7a5697b55",
-                "reference": "d148febc2a2eb82972121d7f962883f7a5697b55",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/7566b4d89de1d08d2a8ad85910507d6633a35d28",
+                "reference": "7566b4d89de1d08d2a8ad85910507d6633a35d28",
                 "shasum": ""
             },
             "require": {
@@ -1826,20 +1826,88 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2023-05-26T22:32:02+00:00"
+            "time": "2023-09-11T11:08:03+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
+            "name": "symfony/deprecation-contracts",
             "version": "dev-main",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "f9c7affe77a00ae32ca127ca6833d034e6d33f25"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f9c7affe77a00ae32ca127ca6833d034e6d33f25",
-                "reference": "f9c7affe77a00ae32ca127ca6833d034e6d33f25",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-23T14:45:45+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "1.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "42292d99c55abe617799667f454222c54c60e229"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
+                "reference": "42292d99c55abe617799667f454222c54c60e229",
                 "shasum": ""
             },
             "require": {
@@ -1894,7 +1962,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/main"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -1910,7 +1978,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-30T17:25:47+00:00"
+            "time": "2023-07-28T09:04:16+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -1918,16 +1986,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "fee83bb21fcdc6d71aec5ec36c017a7368000584"
+                "reference": "10d1fa47a72c01a88184fa026d68a00076639dd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/fee83bb21fcdc6d71aec5ec36c017a7368000584",
-                "reference": "fee83bb21fcdc6d71aec5ec36c017a7368000584",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/10d1fa47a72c01a88184fa026d68a00076639dd1",
+                "reference": "10d1fa47a72c01a88184fa026d68a00076639dd1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
@@ -1936,6 +2005,8 @@
             "require-dev": {
                 "ext-iconv": "*",
                 "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/error-handler": "^6.3|^7.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
                 "symfony/process": "^5.4|^6.0|^7.0",
                 "symfony/uid": "^5.4|^6.0|^7.0",
                 "twig/twig": "^2.13|^3.0.4"
@@ -1992,7 +2063,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-25T13:09:45+00:00"
+            "time": "2023-09-25T12:52:38+00:00"
         },
         {
             "name": "tareq1988/wp-php-cs-fixer",
@@ -2000,12 +2071,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/tareq1988/wp-php-cs-fixer.git",
-                "reference": "eeef65598ae7bac55a09073e666ec0eabf303a12"
+                "reference": "465ea717d0894942bbba260051f0df955286e617"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tareq1988/wp-php-cs-fixer/zipball/eeef65598ae7bac55a09073e666ec0eabf303a12",
-                "reference": "eeef65598ae7bac55a09073e666ec0eabf303a12",
+                "url": "https://api.github.com/repos/tareq1988/wp-php-cs-fixer/zipball/465ea717d0894942bbba260051f0df955286e617",
+                "reference": "465ea717d0894942bbba260051f0df955286e617",
                 "shasum": ""
             },
             "default-branch": true,
@@ -2030,7 +2101,7 @@
                 "issues": "https://github.com/tareq1988/wp-php-cs-fixer/issues",
                 "source": "https://github.com/tareq1988/wp-php-cs-fixer/tree/master"
             },
-            "time": "2022-08-26T09:36:52+00:00"
+            "time": "2023-06-19T06:26:04+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2088,19 +2159,22 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "a328aff1e0b05e55e61a02b9f4faae6482cfc3ad"
+                "reference": "7722c0b8a6f4eb615be4ba8ebe22ed92a5fa87d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/a328aff1e0b05e55e61a02b9f4faae6482cfc3ad",
-                "reference": "a328aff1e0b05e55e61a02b9f4faae6482cfc3ad",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7722c0b8a6f4eb615be4ba8ebe22ed92a5fa87d7",
+                "reference": "7722c0b8a6f4eb615be4ba8ebe22ed92a5fa87d7",
                 "shasum": ""
             },
             "require": {
                 "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.0",
-                "phpcsstandards/phpcsutils": "^1.0.5",
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
                 "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
@@ -2111,6 +2185,7 @@
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
+                "ext-iconv": "For improved results",
                 "ext-mbstring": "For improved results"
             },
             "default-branch": true,
@@ -2137,20 +2212,26 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2023-05-28T19:30:57+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/thewpcc/contribute/wp-php-63406",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-09-20T23:16:50+00:00"
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "6.2.0",
+            "version": "6.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
-                "reference": "3b7ab767dde017dec9327cc024e9f26fd776a57b"
+                "reference": "4797791a311c41d213027333e4fcc48073f77df0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/3b7ab767dde017dec9327cc024e9f26fd776a57b",
-                "reference": "3b7ab767dde017dec9327cc024e9f26fd776a57b",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/4797791a311c41d213027333e4fcc48073f77df0",
+                "reference": "4797791a311c41d213027333e4fcc48073f77df0",
                 "shasum": ""
             },
             "type": "library",
@@ -2185,7 +2266,7 @@
                 "issues": "https://github.com/wp-phpunit/issues",
                 "source": "https://github.com/wp-phpunit/wp-phpunit"
             },
-            "time": "2023-03-30T01:15:51+00:00"
+            "time": "2023-08-09T01:26:57+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
@@ -2193,12 +2274,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "d5a196cc2cb39a9efeeff72ce712efef3c107a45"
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/d5a196cc2cb39a9efeeff72ce712efef3c107a45",
-                "reference": "d5a196cc2cb39a9efeeff72ce712efef3c107a45",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212",
                 "shasum": ""
             },
             "require": {
@@ -2245,7 +2326,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2023-05-19T05:47:22+00:00"
+            "time": "2023-08-19T14:25:08+00:00"
         }
     ],
     "aliases": [],
@@ -2260,5 +2341,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/plugin-stub/includes/PluginStub.php
+++ b/plugin-stub/includes/PluginStub.php
@@ -39,7 +39,7 @@ final class PluginStub {
      *
      * @var array
      */
-    const PLUGIN_STUB_DEPENEDENCIES = [
+    private const PLUGIN_STUB_DEPENEDENCIES = [
         'plugins' => [
             'woocommerce/woocommerce.php',
             'dokan-lite/dokan.php',
@@ -253,16 +253,24 @@ final class PluginStub {
      * @return boolean
      */
     public function check_dependencies() {
-        if ( ! class_exists( 'Woocommerce' ) || ! class_exists( 'WeDevs_Dokan' ) || ! class_exists( 'Dokan_Pro' ) ) {
-            return false;
-        }
-
-        if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) || ! is_plugin_active( 'dokan-lite/dokan.php' ) || ! is_plugin_active( 'dokan-pro/dokan-pro.php' ) ) {
-            return false;
-        }
-
-        if( ! function_exists('dokan_admin_menu_position')) {
-            return false;
+        if( array_key_exists( 'plugins', self::PLUGIN_STUB_DEPENEDENCIES ) && !empty( self::PLUGIN_STUB_DEPENEDENCIES[ 'plugins' ] ) ){
+            for( $plugin_counter = 0; $plugin_counter < count( self::PLUGIN_STUB_DEPENEDENCIES[ 'plugins' ] ); $plugin_counter++ ){
+                if( ! is_plugin_active( self::PLUGIN_STUB_DEPENEDENCIES[ 'plugins' ][$plugin_counter] ) ) {
+                    return false;
+                }
+            }
+        }else if( array_key_exists( 'classes', self::PLUGIN_STUB_DEPENEDENCIES ) && !empty( self::PLUGIN_STUB_DEPENEDENCIES[ 'classes' ] ) ){
+            for( $class_counter = 0; $class_counter < count( self::PLUGIN_STUB_DEPENEDENCIES[ 'classes' ] ); $class_counter++ ){
+                if( ! class_exists( self::PLUGIN_STUB_DEPENEDENCIES[ 'classes' ][$class_counter] ) ) {
+                    return false;
+                }
+            }
+        }else if( array_key_exists( 'functions', self::PLUGIN_STUB_DEPENEDENCIES ) && !empty( self::PLUGIN_STUB_DEPENEDENCIES[ 'functions' ] ) ){
+            for( $func_counter = 0; $func_counter < count( self::PLUGIN_STUB_DEPENEDENCIES[ 'functions' ] ); $func_counter++ ){
+                if( ! function_exists( self::PLUGIN_STUB_DEPENEDENCIES[ 'functions' ][$func_counter] ) ) {
+                    return false;
+                }
+            }
         }
 
         return true;
@@ -274,7 +282,7 @@ final class PluginStub {
      * @return void
      */
     protected function get_dependency_message() {
-        return __( 'Plugin Stub plugin is enabled but not effective. It requires WooCommerce, Dokan Lite & Dokan Pro plugins to work.', 'plugin-stub' );
+        return __( 'Plugin Stub plugin is enabled but not effective. It requires dependency plugins to work.', 'plugin-stub' );
     }
 
     /**

--- a/plugin-stub/includes/PluginStub.php
+++ b/plugin-stub/includes/PluginStub.php
@@ -41,17 +41,17 @@ final class PluginStub {
      */
     private const PLUGIN_STUB_DEPENEDENCIES = [
         'plugins' => [
-            'woocommerce/woocommerce.php',
-            'dokan-lite/dokan.php',
-            'dokan-pro/dokan-pro.php'
+            // 'woocommerce/woocommerce.php',
+            // 'dokan-lite/dokan.php',
+            // 'dokan-pro/dokan-pro.php'
         ],
         'classes' => [
-            'Woocommerce',
-            'WeDevs_Dokan',
-            'Dokan_Pro'
+            // 'Woocommerce',
+            // 'WeDevs_Dokan',
+            // 'Dokan_Pro'
         ],
         'functions' => [
-            'dokan_admin_menu_position'
+            // 'dokan_admin_menu_position'
         ],
     ];
 

--- a/plugin-stub/includes/PluginStub.php
+++ b/plugin-stub/includes/PluginStub.php
@@ -33,6 +33,29 @@ final class PluginStub {
     private $container = [];
 
     /**
+     * Plugin dependencies
+     *
+     * @since 2.6.10
+     *
+     * @var array
+     */
+    const PLUGIN_STUB_DEPENEDENCIES = [
+        'plugins' => [
+            'woocommerce/woocommerce.php',
+            'dokan-lite/dokan.php',
+            'dokan-pro/dokan-pro.php'
+        ],
+        'classes' => [
+            'Woocommerce',
+            'WeDevs_Dokan',
+            'Dokan_Pro'
+        ],
+        'functions' => [
+            'dokan_admin_menu_position'
+        ],
+    ];
+
+    /**
      * Constructor for the PluginStub class
      *
      * Sets up all the appropriate hooks and actions
@@ -235,6 +258,10 @@ final class PluginStub {
         }
 
         if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) || ! is_plugin_active( 'dokan-lite/dokan.php' ) || ! is_plugin_active( 'dokan-pro/dokan-pro.php' ) ) {
+            return false;
+        }
+
+        if( ! function_exists('dokan_admin_menu_position')) {
             return false;
         }
 

--- a/plugin-stub/includes/PluginStub.php
+++ b/plugin-stub/includes/PluginStub.php
@@ -75,9 +75,11 @@ final class PluginStub {
      * Initializes the PluginStub() class
      *
      * Checks for an existing PluginStub instance
-     * and if it doesn't find one, creates it.
+     * and if it doesn't find one then create a new one.
+     *
+     * @return PluginStub
      */
-    public static function init() {
+    public static function init(): self {
         if ( self::$instance === null ) {
 			self::$instance = new self();
 		}
@@ -103,7 +105,7 @@ final class PluginStub {
     /**
      * Placeholder for activation function
      *
-     * Nothing being called here yet.
+     * Nothing is being called here yet.
      */
     public function activate() {
         // Check plugin_stub dependency plugins


### PR DESCRIPTION
I have added a feature to handle dependency plugin errors. Currently, I have implemented two types of checks:
- Upon plugin activation.
- When the composed plugin is activated, and its dependency plugins are also activated, but if the admin deactivates one of its dependency plugins, an error notice will be displayed on the admin panel.